### PR TITLE
Using export namespace for CommonJS export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,30 +2,33 @@ import axios, { AxiosResponse } from 'axios';
 // @ts-ignore
 import querystring from 'querystring';
 
-export interface Parameters {
-    auth_key: string;
-    text: string;
-    source_lang?: 'DE' | 'EN' | 'FR' | 'IT' | 'JA' | 'ES' | 'NL' | 'PL' | 'PT' | 'RU' | 'ZH';
-    target_lang: '';
-    split_sentences?: '0' | '1' | 'nonewlines';
-    preserve_formatting?: '0' | '1';
-    formality?: 'default' | 'more' | 'less';
-    tag_handling?: string[];
-    non_splitting_tags?: string[];
-    outline_detection?: string;
-    splitting_tags?: string[];
-    ignore_tags?: string[];
-}
+// ---- CommonJS export using namespace
+export = translate;
 
-export interface Response {
-    translations: {
-        detected_source_language: string;
-        text: string;
-    }[];
-}
-
-async function translate(parameters: Parameters): Promise<AxiosResponse<Response>> {
+async function translate(parameters: translate.Parameters): Promise<AxiosResponse<translate.Response>> {
     return axios.post('https://api.deepl.com/v2/translate', querystring.stringify(parameters));
 }
 
-export default translate;
+namespace translate {
+    export interface Parameters {
+        auth_key: string;
+        text: string;
+        source_lang?: 'DE' | 'EN' | 'FR' | 'IT' | 'JA' | 'ES' | 'NL' | 'PL' | 'PT' | 'RU' | 'ZH';
+        target_lang: '';
+        split_sentences?: '0' | '1' | 'nonewlines';
+        preserve_formatting?: '0' | '1';
+        formality?: 'default' | 'more' | 'less';
+        tag_handling?: string[];
+        non_splitting_tags?: string[];
+        outline_detection?: string;
+        splitting_tags?: string[];
+        ignore_tags?: string[];
+    }
+
+    export interface Response {
+        translations: {
+            detected_source_language: string;
+            text: string;
+        }[];
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepl",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Deepl API wrapper for node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Using the funkyremi deepL documentation's [usage](https://github.com/funkyremi/deepl#usage) require CommonJS users to import the module using the ` require("deepl")` statement.

Assuming the Typescript code exposes the translate function using
```js
async function translate(...) {...}
export default translate
```
The expected behavior from the following code (picked from the [usage](https://github.com/funkyremi/deepl#usage) documentation)
```js
const translate = require("deepl");
```
is to have the `translate` imported object as a `function`.

Or if we take look at the translate object, it refers to a simple `object` containing a `default` function (not a function wrapper as expected)
```js
{ default: [Function: translate] }
```
resulting in this uncommon CommonJS use of the module
```js
// expected behavior (not working in version 1.0.5)
const result = await translate(...)
// TypeError: translate is not a function

// twisted uncommon CommonJS code to be able to use the imported module
const result = await translate.default(...)
```


Taking a look at the transpiled javascript code, we can see that the transpiler used the new Babel6 export approach by putting the `export default` data into a `default` object inside the module
```js
module.default = translate;
```
hence the uncommon CommonJS imported object representation using a `default` property

----

This issue seems to be well known and has been discussed in the [microsoft TypeScript issue #2719](https://github.com/microsoft/TypeScript/issues/2719).

**In this PR** (v1.0.6) we propose to solve this problem by altering the code using the [**namepsace** solution](https://github.com/microsoft/TypeScript/issues/2719#issuecomment-290412760) proposed by [aluanhaddad](https://github.com/aluanhaddad) in the [referenced issue](https://github.com/microsoft/TypeScript/issues/2719).

This solution allows to keep the **type names exports** for ES6 script imports while allowing CommonJS imports to have direct access to the `translate` function using the `require` statement.