### PR TITLE
Enable transpiling module interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepl",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Deepl API wrapper for node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,18 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "target": "ES6",
     "module": "CommonJS",
     "strict": true,
     "declaration": true,
     "outDir": "dist",
-    "lib": ["ES2018", "DOM"]
+    "lib": [
+      "ES2018",
+      "DOM"
+    ]
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
A common issue when it comes to importing external JS modules inside a TS module is the compilation decision made to "sub import" these modules.

In the case of the deepl module, when a CommonJS requires (as picked from the [usage](https://github.com/funkyremi/deepl#usage) documentation) the module
```js
const translate = require("deepl");
```
and tries to use the `translate` function
```js
translate(...);
```
an error is raised
```
return axios_1.default.post('https://api.deepl.com/v2/translate', querystring_1.default.stringify(parameters));
                                                                                        ^
TypeError: Cannot read property 'stringify' of undefined
    at .../node_modules/deepl/dist/index.js:16:97
```
directly linked to the transpiled version `.../dist/index.js`

This error states that `querystring_1.default` is `undefined`.
Looking at the TS version (untranspiled), we can state that the `querystring` module is used correctly:
```js
// index.ts
querystring.stringify(parameters)
```
but its transpiled version is transformed to use the sub property `default` (along with variable renaming)
```js
// index.js (transpiled version)
querystring_1.default.stringify(parameters)
```

This behavior is due to the transpiler **wrongly assuming** that the imported `querystring` module is also a Babel8 transpiled module and thus make use of its assumeda `default` property "rooting" the module features.

As the `querystring` module is imported as a CommonJS module with no transpilation artefacts (no default property as root of all module features)
```js
{
  unescapeBuffer: [Function: unescapeBuffer],
  unescape: [Function: qsUnescape],
  escape: [Function: qsEscape],
  stringify: [Function: stringify],
  encode: [Function: stringify],
  parse: [Function: parse],
  decode: [Function: parse]
}
```
... the wrong transpiled version use of its unexisting `default` root property leads to a constant error raising.

-----

To solve this issue, we propose to **use the `esModuleInterop` property** inside the TS transpilation configuration (`tsconfig.json`) to indicate the potential (here absolute) use of CommonJS module imports:
```js
{
  "compilerOptions": {
    ...
    "esModuleInterop": true,
    ...
  },
}
```
This features tells the transpiler to include a custom `__importDefault` function in which every module imported is examined to check the presence or not of a `default` root property.
In the case of a CommonJS module, the whole imported module is wrapped inside a (previously non-existing) `default` root property in order to keep the overall transpiled code coherency.
```js
// index.js (transpiled version using the interop custom import function)
var __importDefault = (this && this.__importDefault) || function (mod) {
    return (mod && mod.__esModule) ? mod : { "default": mod };
};
const axios_1 = __importDefault(require("axios"));
const querystring_1 = __importDefault(require("querystring"));
```