### PR TITLE
deepl Free Api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ translate({
   });
 ```
 
+### free api endpoint
+
+``` js
+translate({
+    free_api: true,
+    text: 'I am a text',
+    target_lang: 'FR',
+    auth_key: 'authkey',
+  })
+```
+
 ## Example response
 
 ```json

--- a/index.ts
+++ b/index.ts
@@ -6,11 +6,13 @@ import querystring from 'querystring';
 export = translate;
 
 async function translate(parameters: translate.Parameters): Promise<AxiosResponse<translate.Response>> {
-    return axios.post('https://api.deepl.com/v2/translate', querystring.stringify(parameters));
+    const sub_domain = parameters.free_api ? 'api-free' : 'api';
+    return axios.post(`https://${sub_domain}.deepl.com/v2/translate`, querystring.stringify(parameters));
 }
 
 namespace translate {
     export interface Parameters {
+        free_api: Boolean;
         auth_key: string;
         text: string;
         source_lang?: 'DE' | 'EN' | 'FR' | 'IT' | 'JA' | 'ES' | 'NL' | 'PL' | 'PT' | 'RU' | 'ZH';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deepl",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepl",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Deepl API wrapper for node",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Some users (including myself) use the free DeepL api hosted on `api-free.deepl.com/v2/...` and not `api.deepl.com/v2/...`.

The enhancement I propose allows users to indicate whether they are using the pro or free api in the translation settings (`free_api` boolean property)