### PR TITLE
Create new DeeplLanguages type and export it

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,36 +1,67 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from "axios";
 // @ts-ignore
-import querystring from 'querystring';
+import querystring from "querystring";
 
 // ---- CommonJS export using namespace
 export = translate;
 
-async function translate(parameters: translate.Parameters): Promise<AxiosResponse<translate.Response>> {
-    const sub_domain = parameters.free_api ? 'api-free' : 'api';
-    return axios.post(`https://${sub_domain}.deepl.com/v2/translate`, querystring.stringify(parameters));
+async function translate(
+  parameters: translate.Parameters
+): Promise<AxiosResponse<translate.Response>> {
+  const sub_domain = parameters.free_api ? "api-free" : "api";
+  return axios.post(
+    `https://${sub_domain}.deepl.com/v2/translate`,
+    querystring.stringify(parameters)
+  );
 }
 
 namespace translate {
-    export interface Parameters {
-        free_api: Boolean;
-        auth_key: string;
-        text: string;
-        source_lang?: 'BG' | 'CS' | 'DA' | 'DE' | 'EL' | 'EN' | 'ES' | 'ET' | 'FI' | 'FR' | 'HU' | 'IT' | 'JA' | 'LT' | 'LV' | 'NL' | 'PL' | 'PT' | 'RO' | 'RU' | 'SK' | 'SL' | 'SV' | 'ZH';
-        target_lang: 'BG' | 'CS' | 'DA' | 'DE' | 'EL' | 'EN' | 'ES' | 'ET' | 'FI' | 'FR' | 'HU' | 'IT' | 'JA' | 'LT' | 'LV' | 'NL' | 'PL' | 'PT' | 'RO' | 'RU' | 'SK' | 'SL' | 'SV' | 'ZH';
-        split_sentences?: '0' | '1' | 'nonewlines';
-        preserve_formatting?: '0' | '1';
-        formality?: 'default' | 'more' | 'less';
-        tag_handling?: string[];
-        non_splitting_tags?: string[];
-        outline_detection?: string;
-        splitting_tags?: string[];
-        ignore_tags?: string[];
-    }
+  export type DeeplLanguages =
+    | "BG"
+    | "CS"
+    | "DA"
+    | "DE"
+    | "EL"
+    | "EN"
+    | "ES"
+    | "ET"
+    | "FI"
+    | "FR"
+    | "HU"
+    | "IT"
+    | "JA"
+    | "LT"
+    | "LV"
+    | "NL"
+    | "PL"
+    | "PT"
+    | "RO"
+    | "RU"
+    | "SK"
+    | "SL"
+    | "SV"
+    | "ZH";
 
-    export interface Response {
-        translations: {
-            detected_source_language: string;
-            text: string;
-        }[];
-    }
+  export interface Parameters {
+    free_api: Boolean;
+    auth_key: string;
+    text: string;
+    source_lang?: DeeplLanguages;
+    target_lang: DeeplLanguages;
+    split_sentences?: "0" | "1" | "nonewlines";
+    preserve_formatting?: "0" | "1";
+    formality?: "default" | "more" | "less";
+    tag_handling?: string[];
+    non_splitting_tags?: string[];
+    outline_detection?: string;
+    splitting_tags?: string[];
+    ignore_tags?: string[];
+  }
+
+  export interface Response {
+    translations: {
+      detected_source_language: string;
+      text: string;
+    }[];
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,58 @@
 {
   "name": "deepl",
   "version": "1.0.11",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.11",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "querystring": "^0.2.0"
+      },
+      "devDependencies": {
+        "typescript": "^4.0.2"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "axios": {
       "version": "0.21.1",


### PR DESCRIPTION
This change allows users to cast a string as a DeeplLanguage type and reduces repetitiveness in the code.